### PR TITLE
Remove ruby method from the gemfile

### DIFF
--- a/lib/polariscope/scanner/codebase_health_score.rb
+++ b/lib/polariscope/scanner/codebase_health_score.rb
@@ -34,7 +34,7 @@ module Polariscope
       def gemfile_file
         @gemfile_file ||= begin
           file = Tempfile.new('Gemfile')
-          file.write(gemfile_content.gsub("gemspec\n", ''))
+          file.write(gemfile_content.gsub("gemspec\n", '').gsub(/^ruby.*$\R/, ''))
           file.close
           file
         end


### PR DESCRIPTION
Currently, if you have a Gemfile which specifices the Ruby version via a file:
```ruby
ruby file: '.ruby-version'

gem 'rails'
```
`polariscope scan` will fail with the following error:
```
polariscope scan
e/3.3.5/lib/ruby/gems/3.3.0/gems/bundler-2.5.18/lib/bundler.rb:531:in `initialize':  (Bundler::Dsl::DSLError)
[!] There was an error parsing `Gemfile20241008-99863-zd7g73`: No such file or directory @ rb_sysopen - /var/folders/t8/x1x_37jd2z3bgptl9x43wykm0000gn/T/.ruby-version. Bundler cannot continue.

 #  from /var/folders/t8/x1x_37jd2z3bgptl9x43wykm0000gn/T/Gemfile20241008-99863-zd7g73:5
 #  -------------------------------------------
 #  
 >  ruby file: '.ruby-version'
 #  
 #  -------------------------------------------
```
This is because bundler is trying to open the `.ruby-version` file, which there's no access to.

Since we don't need Ruby version from the Gemfile (it can instead be extracted from Gemfile.lock if necessary), the method can be scrubbed from the file.