### PR TITLE
Include Ruby versions in health score calculation

### DIFF
--- a/lib/polariscope/scanner/calculation_context.rb
+++ b/lib/polariscope/scanner/calculation_context.rb
@@ -3,7 +3,7 @@
 module Polariscope
   module Scanner
     class CalculationContext
-      DEPENDENCY_PRIORITIES = { rails: 10.0 }.freeze
+      DEPENDENCY_PRIORITIES = { ruby: 10.0, rails: 10.0 }.freeze
       GROUP_PRIORITIES = { default: 2.0, production: 2.0 }.freeze
       DEFAULT_DEPENDENCY_PRIORITY = 1.0
 

--- a/lib/polariscope/scanner/dependency_context.rb
+++ b/lib/polariscope/scanner/dependency_context.rb
@@ -73,11 +73,9 @@ module Polariscope
       end
 
       def dependencies_with_ruby
-        if ruby_scanner.version
-          bundle_definition.dependencies + [Bundler::Dependency.new(GemVersions::RUBY_NAME, false)]
-        else
-          bundle_definition.dependencies
-        end
+        return bundle_definition.dependencies unless ruby_scanner.version
+
+        bundle_definition.dependencies + [Bundler::Dependency.new(GemVersions::RUBY_NAME, false)]
       end
 
       def specs

--- a/lib/polariscope/scanner/dependency_context.rb
+++ b/lib/polariscope/scanner/dependency_context.rb
@@ -22,7 +22,7 @@ module Polariscope
       end
 
       def dependencies
-        bundle_definition.dependencies
+        @dependencies ||= dependencies_with_ruby
       end
 
       def dependency_versions(dependency)
@@ -67,7 +67,17 @@ module Polariscope
       end
 
       def current_dependency_version(dependency)
+        return ruby_scanner.version if dependency.name == GemVersions::RUBY_NAME
+
         specs.find { |spec| dependency.name == spec.name }.version
+      end
+
+      def dependencies_with_ruby
+        if ruby_scanner.version
+          bundle_definition.dependencies + [Bundler::Dependency.new(GemVersions::RUBY_NAME, false)]
+        else
+          bundle_definition.dependencies
+        end
       end
 
       def specs

--- a/lib/polariscope/scanner/dependency_context.rb
+++ b/lib/polariscope/scanner/dependency_context.rb
@@ -73,9 +73,15 @@ module Polariscope
       end
 
       def dependencies_with_ruby
-        return bundle_definition.dependencies unless ruby_scanner.version
+        return installed_dependencies unless ruby_scanner.version
 
-        bundle_definition.dependencies + [Bundler::Dependency.new(GemVersions::RUBY_NAME, false)]
+        installed_dependencies + [Bundler::Dependency.new(GemVersions::RUBY_NAME, false)]
+      end
+
+      def installed_dependencies
+        spec_names = specs.to_set(&:name)
+
+        bundle_definition.dependencies.select { |dependency| spec_names.include?(dependency.name) }
       end
 
       def specs

--- a/lib/polariscope/scanner/gem_versions.rb
+++ b/lib/polariscope/scanner/gem_versions.rb
@@ -1,16 +1,21 @@
 # frozen_string_literal: true
 
+require_relative 'ruby_versions'
+
 require 'set'
 
 module Polariscope
   module Scanner
     class GemVersions
+      RUBY_NAME = 'ruby'
+
       def initialize(dependency_names, spec_type:)
         @dependency_names = dependency_names.to_set
         @spec_type = spec_type
         @gem_versions = Hash.new { |h, k| h[k] = Set.new }
 
         fetch_gems
+        fetch_ruby_versions if dependency_names.include?(RUBY_NAME)
       end
 
       def versions_for(gem_name)
@@ -22,6 +27,10 @@ module Polariscope
       attr_reader :dependency_names
       attr_reader :spec_type
       attr_reader :gem_versions
+
+      def fetch_ruby_versions
+        gem_versions[RUBY_NAME] = RubyVersions.available_versions
+      end
 
       def fetch_gems
         gem_tuples.each { |(name_tuple, _)| gem_versions[name_tuple.name] << name_tuple.version }

--- a/lib/polariscope/scanner/ruby_versions.rb
+++ b/lib/polariscope/scanner/ruby_versions.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'open-uri'
+
+module Polariscope
+  module Scanner
+    module RubyVersions
+      VERSIONS_INDEX_FILE_URL = 'https://cache.ruby-lang.org/pub/ruby/index.txt'
+      MINIMUM_RUBY_VERSION = Gem::Version.new('1.0.0')
+      OPEN_TIMEOUT = 5
+      READ_TIMEOUT = 5
+
+      module_function
+
+      def available_versions
+        URI
+          .parse(VERSIONS_INDEX_FILE_URL)
+          .open(open_timeout: OPEN_TIMEOUT, read_timeout: READ_TIMEOUT, &:readlines)
+          .drop(1) # header row
+          .map { |line| line.split("\t").first.sub('ruby-', 'ruby ') } # ruby-2.3.4 -> ruby 2.3.4
+          .filter_map { |ruby_version| Bundler::RubyVersion.from_string(ruby_version)&.gem_version }
+          .select { |gem_version| gem_version >= MINIMUM_RUBY_VERSION }
+          .to_set
+      rescue Timeout::Error
+        Set.new
+      end
+    end
+  end
+end

--- a/lib/polariscope/scanner/ruby_versions.rb
+++ b/lib/polariscope/scanner/ruby_versions.rb
@@ -12,14 +12,14 @@ module Polariscope
 
       module_function
 
-      def available_versions
+      def available_versions # rubocop:disable Metrics/AbcSize
         URI
           .parse(VERSIONS_INDEX_FILE_URL)
           .open(open_timeout: OPEN_TIMEOUT, read_timeout: READ_TIMEOUT, &:readlines)
           .drop(1) # header row
           .map { |line| line.split("\t").first.sub('ruby-', 'ruby ') } # ruby-2.3.4 -> ruby 2.3.4
           .filter_map { |ruby_version| Bundler::RubyVersion.from_string(ruby_version)&.gem_version }
-          .select { |gem_version| gem_version >= MINIMUM_RUBY_VERSION }
+          .select { |gem_version| gem_version >= MINIMUM_RUBY_VERSION && gem_version.segments.size == 3 }
           .to_set
       rescue Timeout::Error
         Set.new

--- a/spec/files/gemfile.lock_with_dependencies
+++ b/spec/files/gemfile.lock_with_dependencies
@@ -191,6 +191,7 @@ DEPENDENCIES
   rspec-rails (~> 5)
   shrine
   sidekiq (~> 6)
+  tzinfo-data
 
 BUNDLED WITH
    2.5.17

--- a/spec/files/gemfile.lock_with_ruby_version
+++ b/spec/files/gemfile.lock_with_ruby_version
@@ -193,7 +193,7 @@ DEPENDENCIES
   sidekiq (~> 6)
 
 RUBY VERSION
-   ruby 3.0.0p100
+   ruby 2.5.0p100
 
 BUNDLED WITH
    2.5.17

--- a/spec/files/gemfile_with_dependencies
+++ b/spec/files/gemfile_with_dependencies
@@ -10,3 +10,6 @@ gem 'sidekiq', '~> 6'
 group :development, :test do
   gem 'rspec-rails', '~> 5'
 end
+
+# dependency which is installed only on some platforms
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/spec/files/gemfile_with_ruby_version
+++ b/spec/files/gemfile_with_ruby_version
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.0.0'
+ruby '2.5.0'
 
 gem 'rails', '~> 7.0.0.0'
 gem 'shrine'

--- a/spec/lib/polariscope/scanner/gem_versions_spec.rb
+++ b/spec/lib/polariscope/scanner/gem_versions_spec.rb
@@ -27,14 +27,20 @@ RSpec.describe Polariscope::Scanner::GemVersions do
   end
 
   describe '#versions_for' do
-    let(:dependencies) { ['devise', 'rails'] }
-
     before { allow(Polariscope::Scanner::RubyVersions).to receive(:available_versions) }
 
-    it 'returns only distinct versions for given gem name' do
-      expect(scanner.versions_for('devise').map(&:to_s)).to contain_exactly('4.6.2', '4.5.0')
+    context 'when ruby is not in dependencies' do
+      let(:dependencies) { ['devise', 'rails'] }
 
-      expect(Polariscope::Scanner::RubyVersions).not_to have_received(:available_versions)
+      it 'returns distinct versions for given gem name' do
+        expect(scanner.versions_for('devise').map(&:to_s)).to contain_exactly('4.6.2', '4.5.0')
+      end
+
+      it "doesn't fetch ruby versions" do
+        scanner
+
+        expect(Polariscope::Scanner::RubyVersions).not_to have_received(:available_versions)
+      end
     end
 
     context 'when ruby is in dependencies' do

--- a/spec/lib/polariscope/scanner/gem_versions_spec.rb
+++ b/spec/lib/polariscope/scanner/gem_versions_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Polariscope::Scanner::GemVersions do
-  subject(:scanner) { described_class.new(['devise', 'rails'], spec_type: :released) }
+  subject(:scanner) { described_class.new(dependencies, spec_type: :released) }
 
   before do
     gem_tuples = [
@@ -27,8 +27,24 @@ RSpec.describe Polariscope::Scanner::GemVersions do
   end
 
   describe '#versions_for' do
+    let(:dependencies) { ['devise', 'rails'] }
+
+    before { allow(Polariscope::Scanner::RubyVersions).to receive(:available_versions) }
+
     it 'returns only distinct versions for given gem name' do
       expect(scanner.versions_for('devise').map(&:to_s)).to contain_exactly('4.6.2', '4.5.0')
+
+      expect(Polariscope::Scanner::RubyVersions).not_to have_received(:available_versions)
+    end
+
+    context 'when ruby is in dependencies' do
+      let(:dependencies) { ['devise', 'ruby', 'rails'] }
+
+      it 'fetches ruby versions' do
+        scanner
+
+        expect(Polariscope::Scanner::RubyVersions).to have_received(:available_versions)
+      end
     end
   end
 end

--- a/spec/lib/polariscope/scanner/ruby_versions_spec.rb
+++ b/spec/lib/polariscope/scanner/ruby_versions_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe Polariscope::Scanner::RubyVersions do
+  subject(:ruby_versions) { described_class }
+
+  describe '.available_versions' do
+    it 'returns published ruby versions' do
+      result = ruby_versions.available_versions
+
+      expect(result).to be_a(Set)
+      expect(result.map(&:class).uniq).to contain_exactly(Gem::Version)
+      expect(result.none?(&:prerelease?)).to be(true)
+      expect(result.min).to eq(Gem::Version.new('1.2.1'))
+    end
+
+    context 'when an open timeout error is raised' do
+      before { allow(URI).to receive(:parse).and_raise(Net::OpenTimeout) }
+
+      it 'returns an empty set' do
+        expect(ruby_versions.available_versions).to eq(Set.new)
+      end
+    end
+
+    context 'when a read timeout error is raised' do
+      before { allow(URI).to receive(:parse).and_raise(Net::ReadTimeout) }
+
+      it 'returns an empty set' do
+        expect(ruby_versions.available_versions).to eq(Set.new)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Makes Ruby versions count towards the health score. The implementation adds Ruby as a dependency, i.e. a gem, so it can work with the existing API.

Released Ruby versions are fetched from `https://cache.ruby-lang.org/pub/ruby/index.txt`, which is an automatically generated file (more info [here](https://bugs.ruby-lang.org/issues/20446)).

Ruby has been given the same priority as Rails, which is 10.