### PR TITLE
Require bundler when loading polariscope

### DIFF
--- a/lib/polariscope.rb
+++ b/lib/polariscope.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bundler'
+
 require_relative 'polariscope/version'
 require_relative 'polariscope/scanner/gemfile_health_score'
 require_relative 'polariscope/scanner/gem_versions'


### PR DESCRIPTION
When used standalone, `bundler` must be required, otherwise an error is raised:
```
polariscope/lib/polariscope/scanner/dependency_context.rb:64:in `block (2 levels) in bundle_definition': uninitialized constant Bundler::Definition (NameError)
        from .rbenv/versions/3.0.7/lib/ruby/3.0.0/tempfile.rb:358:in `create'
        from polariscope/lib/polariscope/scanner/dependency_context.rb:57:in `block in bundle_definition'
        from .rbenv/versions/3.0.7/lib/ruby/3.0.0/tempfile.rb:358:in `create'
        from polariscope/lib/polariscope/scanner/dependency_context.rb:56:in `bundle_definition'
        from polariscope/lib/polariscope/scanner/dependency_context.rb:47:in `ruby_scanner'
        from polariscope/lib/polariscope/scanner/dependency_context.rb:76:in `dependencies_with_ruby'
        from polariscope/lib/polariscope/scanner/dependency_context.rb:25:in `dependencies'
        from polariscope/lib/polariscope/scanner/dependency_context.rb:21:in `no_dependencies?'
        from polariscope/lib/polariscope/scanner/gemfile_health_score.rb:20:in `health_score'
        from polariscope/lib/polariscope.rb:17:in `scan'
```