### PR TITLE
Handle Bundler DSL errors

### DIFF
--- a/lib/polariscope/scanner/dependency_context.rb
+++ b/lib/polariscope/scanner/dependency_context.rb
@@ -51,7 +51,7 @@ module Polariscope
         @gem_versions ||= GemVersions.new(dependencies.map(&:name), spec_type: spec_type)
       end
 
-      def bundle_definition
+      def bundle_definition # rubocop:disable Metrics/MethodLength
         @bundle_definition ||=
           ::Tempfile.create do |gemfile|
             ::Tempfile.create do |gemfile_lock|
@@ -64,6 +64,8 @@ module Polariscope
               Bundler::Definition.build(gemfile.path, gemfile_lock.path, false)
             end
           end
+      rescue Bundler::Dsl::DSLError => e
+        raise Polariscope::Error, "Unable to parse the provided Gemfile/Gemfile.lock: #{e.message}"
       end
 
       def current_dependency_version(dependency)

--- a/spec/files/gemfile.lock_unparseable
+++ b/spec/files/gemfile.lock_unparseable
@@ -1,0 +1,11 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+
+BUNDLED WITH
+   2.2.16

--- a/spec/files/gemfile_unparseable
+++ b/spec/files/gemfile_unparseable
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+eval File.read('unavailable_file')

--- a/spec/lib/polariscope/scanner/dependency_context_spec.rb
+++ b/spec/lib/polariscope/scanner/dependency_context_spec.rb
@@ -83,6 +83,21 @@ RSpec.describe Polariscope::Scanner::DependencyContext do
                                                                                'rspec-rails', 'ruby')
       end
     end
+
+    context 'when gemfile has unparseable content' do
+      let(:opts) do
+        {
+          gemfile_content: File.read('spec/files/gemfile_unparseable'),
+          gemfile_lock_ontent: File.read('spec/files/gemfile.lock_unparseable')
+        }
+      end
+
+      it 'raises an error' do
+        expect do
+          dependency_context.dependencies
+        end.to raise_error(Polariscope::Error, %r{^Unable to parse the provided Gemfile/Gemfile.lock:})
+      end
+    end
   end
 
   describe '#dependency_versions' do


### PR DESCRIPTION
Given a Gemfile/Gemfile.lock that cannot be loaded by Bundler ([despite already parsing it](https://github.com/infinum/polariscope/blob/5ff30137e6188db6cf5aa51007f6f6b1db7be03f/lib/polariscope/scanner/dependency_context.rb#L110-L112)), `DSLError` is rescued and `Polariscope::Error` is raised instead.