### PR TITLE
Add ability to skip updating audit DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Add `update_audit_database` option to `Polariscope.scan` to control whether to update the audit DB
+
 ## [0.5.0] - 2024-10-30
 
 - Fix regression for standalone installation

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Polariscope.scan(
   new_versions_severity: 1.09, # number >= 1
   segment_severities: [1.7, 1.15, 1.01], # ordered by segments: [major, minor, patch]
   fallback_segment_severity: 1.01, # in case dependency versions have more segments than in segment_severities
+  update_audit_database: false, # Polariscope by default updates audit DB if it's older more than one day
 )
 ```
 

--- a/lib/polariscope.rb
+++ b/lib/polariscope.rb
@@ -12,11 +12,12 @@ module Polariscope
 
   class << self
     def scan(**opts)
-      Scanner::GemfileHealthScore.new(**opts.merge(
+      Scanner::GemfileHealthScore.new(
+        **opts,
         gemfile_content: opts.fetch(:gemfile_content, FileContent.for('Gemfile')),
         gemfile_lock_content: opts.fetch(:gemfile_lock_content, FileContent.for('Gemfile.lock')),
         bundler_audit_config_content: opts.fetch(:bundler_audit_config_content, FileContent.for('.bundler-audit.yml'))
-      )).health_score
+      ).health_score
     end
 
     def gem_versions(dependency_names, spec_type: Scanner::DependencyContext::DEFAULT_SPEC_TYPE)

--- a/lib/polariscope/scanner/gemfile_health_score.rb
+++ b/lib/polariscope/scanner/gemfile_health_score.rb
@@ -13,7 +13,7 @@ module Polariscope
         @dependency_context = DependencyContext.new(**opts)
         @calculation_context = CalculationContext.new(**opts)
 
-        AuditDatabase.update_if_necessary
+        AuditDatabase.update_if_necessary if opts.fetch(:update_audit_database, true)
       end
 
       def health_score

--- a/spec/lib/polariscope/scanner/gemfile_health_score_spec.rb
+++ b/spec/lib/polariscope/scanner/gemfile_health_score_spec.rb
@@ -1,58 +1,78 @@
 # frozen_string_literal: true
 
 RSpec.describe Polariscope::Scanner::GemfileHealthScore do
-  subject(:health_score) do
-    described_class.new(
-      gemfile_content: gemfile_content,
-      gemfile_lock_content: gemfile_lock_content,
-      bundler_audit_config_content: bundler_audit_config_content
-    ).health_score
-  end
+  describe '#new' do
+    it 'updates audit database by default' do
+      allow(Polariscope::Scanner::AuditDatabase).to receive(:update_if_necessary)
 
-  context 'when no dependencies found' do
-    let(:gemfile_content) { File.read('spec/files/gemfile_with_no_dependencies') }
-    let(:gemfile_lock_content) { File.read('spec/files/gemfile.lock_with_no_dependencies') }
-    let(:bundler_audit_config_content) { '' }
+      described_class.new
 
-    it { is_expected.to be_nil }
-  end
-
-  # these tests run in the order they're defined and assert that each next test
-  # has a score lower than the previous one
-  describe 'scores', order: :defined do
-    last_score = nil
-
-    context 'when dependencies found and some new versions ignored' do
-      let(:gemfile_content) { File.read('spec/files/gemfile_with_dependencies') }
-      let(:gemfile_lock_content) { File.read('spec/files/gemfile.lock_with_dependencies') }
-      let(:bundler_audit_config_content) { File.read('spec/files/bundler-audit') }
-
-      it 'returns a score' do
-        expect(health_score).to be <= 43.32
-
-        last_score = health_score
-      end
+      expect(Polariscope::Scanner::AuditDatabase).to have_received(:update_if_necessary)
     end
 
-    context 'when dependencies found and no new version is ignored' do
-      let(:gemfile_content) { File.read('spec/files/gemfile_with_dependencies') }
-      let(:gemfile_lock_content) { File.read('spec/files/gemfile.lock_with_dependencies') }
-      let(:bundler_audit_config_content) { '' }
+    it "doesn't update audit database when update_audit_database is false" do
+      allow(Polariscope::Scanner::AuditDatabase).to receive(:update_if_necessary)
 
-      it 'returns a score' do
-        expect(health_score).to be < last_score
+      described_class.new(update_audit_database: false)
 
-        last_score = health_score
-      end
+      expect(Polariscope::Scanner::AuditDatabase).not_to have_received(:update_if_necessary)
+    end
+  end
+
+  describe '#health_score' do
+    subject(:health_score) do
+      described_class.new(
+        gemfile_content: gemfile_content,
+        gemfile_lock_content: gemfile_lock_content,
+        bundler_audit_config_content: bundler_audit_config_content
+      ).health_score
     end
 
-    context 'when Gemfile.lock has a Ruby version' do
-      let(:gemfile_content) { File.read('spec/files/gemfile_with_ruby_version') }
-      let(:gemfile_lock_content) { File.read('spec/files/gemfile.lock_with_ruby_version') }
+    context 'when no dependencies found' do
+      let(:gemfile_content) { File.read('spec/files/gemfile_with_no_dependencies') }
+      let(:gemfile_lock_content) { File.read('spec/files/gemfile.lock_with_no_dependencies') }
       let(:bundler_audit_config_content) { '' }
 
-      it 'returns a score' do
-        expect(health_score).to be < last_score
+      it { is_expected.to be_nil }
+    end
+
+    # these tests run in the order they're defined and assert that each next test
+    # has a score lower than the previous one
+    describe 'scores', order: :defined do
+      last_score = nil
+
+      context 'when dependencies found and some new versions ignored' do
+        let(:gemfile_content) { File.read('spec/files/gemfile_with_dependencies') }
+        let(:gemfile_lock_content) { File.read('spec/files/gemfile.lock_with_dependencies') }
+        let(:bundler_audit_config_content) { File.read('spec/files/bundler-audit') }
+
+        it 'returns a score' do
+          expect(health_score).to be <= 43.32
+
+          last_score = health_score
+        end
+      end
+
+      context 'when dependencies found and no new version is ignored' do
+        let(:gemfile_content) { File.read('spec/files/gemfile_with_dependencies') }
+        let(:gemfile_lock_content) { File.read('spec/files/gemfile.lock_with_dependencies') }
+        let(:bundler_audit_config_content) { '' }
+
+        it 'returns a score' do
+          expect(health_score).to be < last_score
+
+          last_score = health_score
+        end
+      end
+
+      context 'when Gemfile.lock has a Ruby version' do
+        let(:gemfile_content) { File.read('spec/files/gemfile_with_ruby_version') }
+        let(:gemfile_lock_content) { File.read('spec/files/gemfile.lock_with_ruby_version') }
+        let(:bundler_audit_config_content) { '' }
+
+        it 'returns a score' do
+          expect(health_score).to be < last_score
+        end
       end
     end
   end


### PR DESCRIPTION
In multi-threaded environments, bundler-audit DB check fails because it uses thread-unsafe code (more info here https://github.com/rubysec/bundler-audit/pull/397). This PR adds `update_audit_database` option to `Polariscope.scan` to turn audit DB check off. Users who turn this check off are required to update the audit DB manually.